### PR TITLE
codetainer: modify docker daemon command in error log

### DIFF
--- a/config.go
+++ b/config.go
@@ -179,7 +179,7 @@ configured the Docker API to accept remote HTTP connections?
 E.g., your docker service needs to have the following parameters in the
 command line in order to use web sockets:
 
-  /usr/bin/docker -d -H tcp://127.0.0.1:4500
+  /usr/bin/docker daemon -H tcp://127.0.0.1:4500
 
 Please also check your config.toml has the correct configuration for the DockerServer
 and DockerPort:


### PR DESCRIPTION
`docker -d` option is officially deprecated as follows:

```sh
$ docker -d
Warning: '-d' is deprecated, it will be removed soon. See usage.
WARN[0000] please use 'docker daemon' instead.
```

Changed `docker -d` to `docker daemon`.

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>