### PR TITLE
codetainer: support TLS auth

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -74,6 +74,10 @@
 			"Rev": "897b8800a7d1a93518b87c00e5d1c5d7476f3701"
 		},
 		{
+			"ImportPath": "github.com/mitchellh/go-homedir",
+			"Rev": "df55a15e5ce646808815381b3db47a8c66ea62f4"
+		},
+		{
 			"ImportPath": "github.com/pborman/uuid",
 			"Rev": "cccd189d45f7ac3368a0d127efb7f4d08ae0b655"
 		},

--- a/Godeps/_workspace/src/github.com/mitchellh/go-homedir/LICENSE
+++ b/Godeps/_workspace/src/github.com/mitchellh/go-homedir/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/mitchellh/go-homedir/README.md
+++ b/Godeps/_workspace/src/github.com/mitchellh/go-homedir/README.md
@@ -1,0 +1,14 @@
+# go-homedir
+
+This is a Go library for detecting the user's home directory without
+the use of cgo, so the library can be used in cross-compilation environments.
+
+Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
+for a user, and `homedir.Expand()` to expand the `~` in a path to the home
+directory.
+
+**Why not just use `os/user`?** The built-in `os/user` package requires
+cgo on Darwin systems. This means that any Go code that uses that package
+cannot cross compile. But 99% of the time the use for `os/user` is just to
+retrieve the home directory, which we can do for the current user without
+cgo. This library does that, enabling cross-compilation.

--- a/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir.go
@@ -1,0 +1,112 @@
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// DisableCache will disable caching of the home directory. Caching is enabled
+// by default.
+var DisableCache bool
+
+var homedirCache string
+var cacheLock sync.RWMutex
+
+// Dir returns the home directory for the executing user.
+//
+// This uses an OS-specific method for discovering the home directory.
+// An error is returned if a home directory cannot be detected.
+func Dir() (string, error) {
+	if !DisableCache {
+		cacheLock.RLock()
+		cached := homedirCache
+		cacheLock.RUnlock()
+		if cached != "" {
+			return cached, nil
+		}
+	}
+
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
+	var result string
+	var err error
+	if runtime.GOOS == "windows" {
+		result, err = dirWindows()
+	} else {
+		// Unix-like system, so just assume Unix
+		result, err = dirUnix()
+	}
+
+	if err != nil {
+		return "", err
+	}
+	homedirCache = result
+	return result, nil
+}
+
+// Expand expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func Expand(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}
+
+func dirUnix() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try the shell
+	var stdout bytes.Buffer
+	cmd := exec.Command("sh", "-c", "eval echo ~$USER")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}
+
+func dirWindows() (string, error) {
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/go-homedir/homedir_test.go
@@ -1,0 +1,112 @@
+package homedir
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"testing"
+)
+
+func patchEnv(key, value string) func() {
+	bck := os.Getenv(key)
+	deferFunc := func() {
+		os.Setenv(key, bck)
+	}
+
+	os.Setenv(key, value)
+	return deferFunc
+}
+
+func BenchmarkDir(b *testing.B) {
+	// We do this for any "warmups"
+	for i := 0; i < 10; i++ {
+		Dir()
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Dir()
+	}
+}
+
+func TestDir(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	cases := []struct {
+		Input  string
+		Output string
+		Err    bool
+	}{
+		{
+			"/foo",
+			"/foo",
+			false,
+		},
+
+		{
+			"~/foo",
+			fmt.Sprintf("%s/foo", u.HomeDir),
+			false,
+		},
+
+		{
+			"",
+			"",
+			false,
+		},
+
+		{
+			"~",
+			u.HomeDir,
+			false,
+		},
+
+		{
+			"~foo/foo",
+			"",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		actual, err := Expand(tc.Input)
+		if (err != nil) != tc.Err {
+			t.Fatalf("Input: %#v\n\nErr: %s", tc.Input, err)
+		}
+
+		if actual != tc.Output {
+			t.Fatalf("Input: %#v\n\nOutput: %#v", tc.Input, actual)
+		}
+	}
+
+	DisableCache = true
+	defer func() { DisableCache = false }()
+	defer patchEnv("HOME", "/custom/path/")()
+	expected := "/custom/path/foo/bar"
+	actual, err := Expand("~/foo/bar")
+
+	if err != nil {
+		t.Errorf("No error is expected, got: %v", err)
+	} else if actual != "/custom/path/foo/bar" {
+		t.Errorf("Expected: %v; actual: %v", expected, actual)
+	}
+}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ time you run codetainer, please edit defaults as appropriate.
 # Docker API server and port
 DockerServer = "localhost"
 DockerPort = 4500
-# Database path (optional, default is ~/codetainer/codetainer.db)
+
+# Enable TLS support (optional, if you access to Docker API over HTTPS)
+# DockerServerUseHttps = true
+# Certificate directory path (optional)
+#   e.g. if you use Docker Machine: "~/.docker/machine/certs"
+# DockerCertPath = "/path/to/certs"
+
+# Database path (optional, default is ~/.codetainer/codetainer.db)
 # DatabasePath = "/path/to/codetainer.db"
 ```
 


### PR DESCRIPTION
resolve #17 

Add support to use TLS authentication when connecting to Docker API over HTTPS.
Docker's TLS auth needs certificate files, so I added a config item to specify the cert directory.

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>