### PR TITLE
codetainer: support WebSocket over HTTPS

### DIFF
--- a/container.go
+++ b/container.go
@@ -2,6 +2,7 @@ package codetainer
 
 import (
 	"bytes"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"net/url"
@@ -120,13 +121,18 @@ func (c *ContainerConnection) openSocketToContainer() error {
 		return err
 	}
 
-	rawConn, err := net.Dial("tcp", u.Host)
+	var rawConn net.Conn
+	if GlobalConfig.DockerServerUseHttps {
+		rawConn, err = tls.Dial("tcp", u.Host, GlobalConfig.tlsConfig)
+	} else {
+		rawConn, err = net.Dial("tcp", u.Host)
+	}
 	if err != nil {
 		return err
 	}
 
 	wsHeaders := http.Header{
-		"Origin": {"http://localhost:4500"},
+		"Origin": {endpoint},
 	}
 
 	wsConn, resp, err := websocket.NewClient(rawConn, u, wsHeaders, 1024, 1024)


### PR DESCRIPTION
Additional fix for #17 

When using HTTPS to connect Docker daemon, currently the browser console via WebSocket doesn't work and the session is terminated immediately.

I made `Config` hold `*tls.Config` and changed to use `tls.Dial()` instead of `net.Dial()` when creating a `net.Conn` object.

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>