### PR TITLE
Bump the go-dockerclient version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -29,7 +29,7 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Rev": "c9ad0ce23f68428421adfc6ced9e6123f54788a5"
+			"Rev": "d1f46ee3921b42bd217fb81a044e5cb1e03c0383"
 		},
 		{
 			"ImportPath": "github.com/go-xorm/core",


### PR DESCRIPTION
Update the go-dockerclient to the latest stable version in order to be able to work with the most recent Docker API. All existing tests pass.